### PR TITLE
feat: add redux devtool support

### DIFF
--- a/packages/reactive/package.json
+++ b/packages/reactive/package.json
@@ -50,6 +50,7 @@
   "devDependencies": {
     "@testing-library/react": "^12.1.5",
     "@testing-library/react-hooks": "^8.0.1",
+    "@types/node": "^20.4.5",
     "@types/react": "17.0.62",
     "@vitest/coverage-v8": "^0.33.0",
     "react": "^16",

--- a/packages/reactive/package.json
+++ b/packages/reactive/package.json
@@ -42,6 +42,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@redux-devtools/extension": "^3.2.5",
     "@types/use-sync-external-store": "^0.0.3",
     "proxy-compare": "^2.5.1",
     "use-sync-external-store": "^1.2.0"

--- a/packages/reactive/pnpm-lock.yaml
+++ b/packages/reactive/pnpm-lock.yaml
@@ -25,6 +25,9 @@ devDependencies:
   '@testing-library/react-hooks':
     specifier: ^8.0.1
     version: 8.0.1(@types/react@17.0.62)(react-dom@16.14.0)(react-test-renderer@16.14.0)(react@16.14.0)
+  '@types/node':
+    specifier: ^20.4.5
+    version: 20.4.5
   '@types/react':
     specifier: 17.0.62
     version: 17.0.62
@@ -637,6 +640,10 @@ packages:
 
   /@types/node@20.4.0:
     resolution: {integrity: sha512-jfT7iTf/4kOQ9S7CHV9BIyRaQqHu67mOjsIQBC3BKZvzvUB6zLxEwJ6sBE3ozcvP8kF6Uk5PXN0Q+c0dfhGX0g==}
+    dev: true
+
+  /@types/node@20.4.5:
+    resolution: {integrity: sha512-rt40Nk13II9JwQBdeYqmbn2Q6IVTA5uPhvSO+JVqdXw/6/4glI6oR9ezty/A9Hg5u7JH4OmYmuQ+XvjKm0Datg==}
     dev: true
 
   /@types/prop-types@15.7.5:
@@ -2299,6 +2306,7 @@ time:
   /@redux-devtools/extension@3.2.5: '2023-01-16T13:29:24.900Z'
   /@testing-library/react-hooks@8.0.1: '2022-06-18T13:20:19.073Z'
   /@testing-library/react@12.1.5: '2022-04-11T20:14:35.067Z'
+  /@types/node@20.4.5: '2023-07-25T19:03:01.439Z'
   /@types/react@17.0.62: '2023-06-13T15:32:56.674Z'
   /@types/use-sync-external-store@0.0.3: '2021-11-03T17:32:09.624Z'
   /@vitest/coverage-v8@0.33.0: '2023-07-06T14:12:17.283Z'

--- a/packages/reactive/pnpm-lock.yaml
+++ b/packages/reactive/pnpm-lock.yaml
@@ -5,6 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
+  '@redux-devtools/extension':
+    specifier: ^3.2.5
+    version: 3.2.5(redux@4.2.1)
   '@types/use-sync-external-store':
     specifier: ^0.0.3
     version: 0.0.3
@@ -80,7 +83,6 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       regenerator-runtime: 0.13.11
-    dev: true
 
   /@bcoe/v8-coverage@0.2.3:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
@@ -548,6 +550,16 @@ packages:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.15.0
     dev: true
+
+  /@redux-devtools/extension@3.2.5(redux@4.2.1):
+    resolution: {integrity: sha512-UhyDF7WmdnCrN1s++YC4sdQCo0z6YUnoB2eCh15nXDDq3QH1jDju1144UNRU6Nvi4inxhaIum4m9BXVYWVC1ng==}
+    peerDependencies:
+      redux: ^3.1.0 || ^4.0.0
+    dependencies:
+      '@babel/runtime': 7.22.6
+      immutable: 4.3.0
+      redux: 4.2.1
+    dev: false
 
   /@sinclair/typebox@0.27.8:
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
@@ -1249,6 +1261,10 @@ packages:
     engines: {node: '>= 4'}
     dev: true
 
+  /immutable@4.3.0:
+    resolution: {integrity: sha512-0AOCmOip+xgJwEVTQj1EfiDDOkPmuyllDuTuEX+DDXUgapLAsBIfkg3sxCYyCEA8mQqZrrxPUGjcOQ2JS3WLkg==}
+    dev: false
+
   /inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
     dependencies:
@@ -1798,9 +1814,14 @@ packages:
       picomatch: 2.3.1
     dev: true
 
+  /redux@4.2.1:
+    resolution: {integrity: sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==}
+    dependencies:
+      '@babel/runtime': 7.22.6
+    dev: false
+
   /regenerator-runtime@0.13.11:
     resolution: {integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==}
-    dev: true
 
   /regexp.prototype.flags@1.5.0:
     resolution: {integrity: sha512-0SutC3pNudRKgquxGoRGIz946MZVHqbNfPjBdxeOhBrdgDKlRoXmYLQN9xRbrR09ZXWeGAdPuif7egofn6v5LA==}
@@ -2275,6 +2296,7 @@ packages:
     dev: true
 
 time:
+  /@redux-devtools/extension@3.2.5: '2023-01-16T13:29:24.900Z'
   /@testing-library/react-hooks@8.0.1: '2022-06-18T13:20:19.073Z'
   /@testing-library/react@12.1.5: '2022-04-11T20:14:35.067Z'
   /@types/react@17.0.62: '2023-06-13T15:32:56.674Z'

--- a/packages/reactive/src/devtool.ts
+++ b/packages/reactive/src/devtool.ts
@@ -1,1 +1,82 @@
-export function devtool(){}
+import { proxy, subscribe } from "./index.js";
+import { getSnapshot } from "./utils.js";
+
+import type { CreateOptions } from "./index.js";
+
+export type ExtensionActionType =
+  | "START"
+  | "ROLLBACK"
+  | "RESET"
+  | "COMMIT"
+  | "JUMP_TO_ACTION"
+  | "TOGGLE_ACTION";
+
+export interface MessageType {
+  type: "DISPATCH";
+  source: string | undefined;
+  id: string | undefined;
+  state: string | undefined;
+  payload: {
+    type: ExtensionActionType;
+    timestamp: number;
+    actionId?: string;
+  };
+}
+
+interface ConnectResponse {
+  init: (state: unknown) => void;
+  send: (action: { type: string }, state: unknown) => void;
+  subscribe: (handler: (message: MessageType) => void) => any;
+  unsubscribe: (...args: any[]) => any;
+  error: (...args: any[]) => any;
+}
+
+const ext = window.__REDUX_DEVTOOLS_EXTENSION__;
+
+export function enableDevtool(
+  state: ReturnType<typeof proxy>,
+  options: CreateOptions,
+  restore: () => void
+) {
+  if (!ext) {
+    const infos = [
+      "to enable it, make sure you've installed the redux devtool extension: ",
+      "https://github.com/reduxjs/redux-devtools#redux-devtools",
+    ];
+
+    throw new Error(infos.join(""));
+  }
+
+  const name = options.devtool.name;
+  const devtool = ext.connect({ ...options, name }) as ConnectResponse;
+
+  devtool.init(getSnapshot(state));
+
+  devtool.subscribe((message) => {
+    console.debug("message: ", message);
+
+    if (message.type !== "DISPATCH") {
+      return;
+    }
+
+    if (message.payload && message.payload.type === "RESET") {
+      restore();
+    } else {
+      if (!message.state) {
+        return;
+      }
+
+      const actions = ["ROLLBACK", "COMMIT", "JUMP_TO_ACTION"];
+
+      if (actions.includes(message.payload.type)) {
+        Object.assign(state, JSON.parse(message.state || ""));
+      }
+    }
+  });
+
+  subscribe(state, () => {
+    devtool.send({ type: "STORE_CHANGED" }, getSnapshot(state));
+  });
+
+  return () => devtool.unsubscribe();
+}

--- a/packages/reactive/src/devtool.ts
+++ b/packages/reactive/src/devtool.ts
@@ -1,0 +1,1 @@
+export function devtool(){}

--- a/packages/reactive/src/index.ts
+++ b/packages/reactive/src/index.ts
@@ -3,8 +3,13 @@ import { Config as ReduxDevtoolConfig } from "@redux-devtools/extension";
 import { proxy } from "./proxy.js";
 import { useSnapshot } from "./use-snapshot.js";
 import { subscribe } from "./subscribe.js";
-import { DeepReadonly } from "./utils.js";
 import { enableDevtool } from "./devtool.js";
+
+import {
+  isProduction,
+  type DeepReadonly,
+  type DeepExpandType,
+} from "./utils.js";
 
 export type CreateReturn<T extends object> = Readonly<{
   mutate: T;
@@ -13,20 +18,22 @@ export type CreateReturn<T extends object> = Readonly<{
   restore: () => void;
 }>;
 
-/** initial options for creation */
-export interface CreateOptions extends ReduxDevtoolConfig {
-  /** devtool options, if set, will enable redux devtool */
-  devtool?: {
-    /**
-     * name of the store, will be displayed in devtool panel
-     */
+/** redux devtool options, if set, will enable redux devtool */
+export type DevtoolOptions = DeepExpandType<
+  {
+    /* name of the store, will be displayed as title in devtool switch panel */
     name: string;
     /**
      * if set to true, will enable forever whenever production or not
      * @default false
      * */
     forceEnable?: boolean;
-  };
+  } & ReduxDevtoolConfig
+>;
+
+/** initial options for creation */
+export interface CreateOptions {
+  devtool?: DevtoolOptions;
 }
 
 export function create<T extends object>(
@@ -47,11 +54,8 @@ export function create<T extends object>(
       throw new Error("devtool.name is required");
     }
 
-    // FIXME: need to be implemented
-    const isProduction = false;
-
     if (!isProduction || options?.devtool?.forceEnable) {
-      const disableDevtool = enableDevtool(state, options, restore);
+      const disableDevtool = enableDevtool(state, options.devtool, restore);
     }
   }
 

--- a/packages/reactive/src/index.ts
+++ b/packages/reactive/src/index.ts
@@ -1,15 +1,11 @@
-import { Config as ReduxDevtoolConfig } from "@redux-devtools/extension";
-
 import { proxy } from "./proxy.js";
 import { useSnapshot } from "./use-snapshot.js";
 import { subscribe } from "./subscribe.js";
 import { enableDevtool } from "./devtool.js";
+import { isProduction } from "./utils.js";
 
-import {
-  isProduction,
-  type DeepReadonly,
-  type DeepExpandType,
-} from "./utils.js";
+import type { Config as ReduxDevtoolConfig } from "@redux-devtools/extension";
+import type { DeepReadonly, DeepExpandType } from "./utils.js";
 
 export type CreateReturn<T extends object> = Readonly<{
   mutate: T;

--- a/packages/reactive/src/index.ts
+++ b/packages/reactive/src/index.ts
@@ -10,7 +10,26 @@ export type CreateReturn<T extends object> = Readonly<{
   restore: () => void;
 }>;
 
-export function create<T extends object>(initState: T): CreateReturn<T> {
+/** initial options for creation */
+export interface CreateOptions {
+  /** devtool options, if set, will enable redux devtool */
+  devtool?: {
+    /**
+     * name of the store, will be displayed in devtool panel
+     */
+    name: string;
+    /**
+     * if set to true, will enable forever whenever production or not
+     * @default false
+     * */
+    forceEnable?: boolean;
+  };
+}
+
+export function create<T extends object>(
+  initState: T,
+  options?: CreateOptions
+): CreateReturn<T> {
   const state = proxy(initState);
   return {
     mutate: state,

--- a/packages/reactive/src/use-snapshot.ts
+++ b/packages/reactive/src/use-snapshot.ts
@@ -1,8 +1,10 @@
 import { useCallback, useRef } from "react";
-import { DeepReadonly, getSnapshot } from "./utils.js";
-import { useSyncExternalStoreWithSelector } from "use-sync-external-store/shim/with-selector.js";
 import { createProxy, isChanged } from "proxy-compare";
+import { useSyncExternalStoreWithSelector } from "use-sync-external-store/shim/with-selector.js";
+import { getSnapshot } from "./utils.js";
 import { subscribe } from "./subscribe.js";
+
+import type { DeepReadonly } from "./utils.js";
 
 export function useSnapshot<T extends object>(proxyState: T): DeepReadonly<T> {
   const affected = new WeakMap();

--- a/packages/reactive/src/utils.ts
+++ b/packages/reactive/src/utils.ts
@@ -30,3 +30,11 @@ export function getSnapshot<T extends object>(proxyState: T): T {
 export type DeepReadonly<T> = {
   readonly [K in keyof T]: T[K] extends object ? DeepReadonly<T[K]> : T[K];
 };
+
+export type DeepExpandType<T> = {
+  [K in keyof T]: T[K] extends object ? DeepExpandType<T[K]> : T[K];
+};
+
+export const isProduction = process?.env?.NODE_ENV === "production";
+
+export const REACTIVE_STORE_CHANGED = "REACTIVE_STORE_CHANGED";


### PR DESCRIPTION
- 新增：新增对 redux devtool 浏览器扩展的支持。

需要安装 [redux devtool](https://github.com/reduxjs/redux-devtools/tree/main#redux-devtools) 浏览器插件，由于和 redux 的某些概念有冲突，并不是完美兼容，部分功能可能不合预期。

```ts
const store = create(defaultState, {
  devtool: {
    name: 'store-name', // name is required

    // other options here, see  👇
    // https://github.com/reduxjs/redux-devtools/blob/main/extension/docs/API/Arguments.md
    trace: true,
	// ...
  },
});
```