### PR TITLE
fix: fix breakdown in node & `process` not found error

### DIFF
--- a/packages/reactive/src/devtool.ts
+++ b/packages/reactive/src/devtool.ts
@@ -32,7 +32,7 @@ interface ConnectResponse {
   error: (...args: any[]) => any;
 }
 
-const ext = window.__REDUX_DEVTOOLS_EXTENSION__;
+const ext = globalThis.__REDUX_DEVTOOLS_EXTENSION__;
 
 export function enableDevtool(
   state: ReturnType<typeof proxy>,

--- a/packages/reactive/src/utils.ts
+++ b/packages/reactive/src/utils.ts
@@ -35,6 +35,6 @@ export type DeepExpandType<T> = {
   [K in keyof T]: T[K] extends object ? DeepExpandType<T[K]> : T[K];
 };
 
-export const isProduction = process?.env?.NODE_ENV === "production";
+export const isProduction = process.env.NODE_ENV === "production";
 
 export const REACTIVE_STORE_CHANGED = "REACTIVE_STORE_CHANGED";


### PR DESCRIPTION
- Typically, the `NODE_ENV` environment variable is accessed as `process.env.NODE_ENV` and cannot be divided into multiple parts, such as [vite](https://github.com/vitejs/vite/blob/main/packages/vite/src/node/plugins/clientInjections.ts#L90-L98). If the `optional chaining` syntax is used, it might result in unexpected separation.
```javascript
// ❌ `process.env.NODE_ENV` is NOT used as a whole
if (process?.env?.NODE_ENV === 'production') {
  // prod
} else {
  // dev
}

// ✅ `process.env.NODE_ENV` is used as a whole
if (process.env.NODE_ENV === 'production') {
  // prod
} else {
  // dev
}
```

- In Node.js, the `window` object is not defined. Therefore, it is recommended to use `globalThis`, which represents a global object that is accessible in both Node.js and the browser.

```javascript
// ❌ only works in Browser
if (window.__SOME_VALUE__) {
  // some code here...
}

// ✅ works both in Browser and Node.js
if (globalThis.__SOME_VALUE__) {
  // some code here...
}
```

