### PR TITLE
feat: support remove readonly hack in some cases

### DIFF
--- a/packages/reactive/hack-remove-readonly.d.ts
+++ b/packages/reactive/hack-remove-readonly.d.ts
@@ -1,0 +1,55 @@
+declare module "@shined/reactive" {
+  import { Config } from "@redux-devtools/extension";
+
+  function proxy<T extends object>(initState: T): T;
+
+  type DeepExpandType<T> = {
+    [K in keyof T]: T[K] extends object ? DeepExpandType<T[K]> : T[K];
+  };
+
+  function useSnapshot<T extends object>(proxyState: T): T;
+
+  function subscribe<T extends object>(
+    proxyObject: T,
+    callback: () => void
+  ): () => void;
+
+  type CreateReturn<T extends object> = Readonly<{
+    mutate: T;
+    useSnapshot: () => T;
+    subscribe: (callback: () => void) => () => void;
+    restore: () => void;
+  }>;
+
+  /** redux devtool options, if set, will enable redux devtool */
+  type DevtoolOptions = DeepExpandType<
+    {
+      name: string;
+      /**
+       * if set to true, will enable forever whenever production or not
+       * @default false
+       * */
+      forceEnable?: boolean;
+    } & Config
+  >;
+
+  /** initial options for creation */
+  interface CreateOptions {
+    devtool?: DevtoolOptions;
+  }
+
+  function create<T extends object>(
+    initState: T,
+    options?: CreateOptions
+  ): CreateReturn<T>;
+
+  export {
+    CreateOptions,
+    CreateReturn,
+    DevtoolOptions,
+    create,
+    proxy,
+    subscribe,
+    useSnapshot,
+  };
+}

--- a/packages/reactive/package.json
+++ b/packages/reactive/package.json
@@ -20,6 +20,9 @@
       "import": "./dist/index.js",
       "default": "./dist/index.js"
     },
+    "./hack-remove-readonly": {
+      "types": "./hack-remove-readonly.d.ts"
+    },
     "./package.json": "./package.json"
   },
   "publishConfig": {

--- a/packages/reactive/src/utils.ts
+++ b/packages/reactive/src/utils.ts
@@ -31,6 +31,10 @@ export type DeepReadonly<T> = {
   readonly [K in keyof T]: T[K] extends object ? DeepReadonly<T[K]> : T[K];
 };
 
+export type DeepWritable<T> = {
+  -readonly [K in keyof T]: T[K] extends object ? DeepWritable<T[K]> : T[K];
+};
+
 export type DeepExpandType<T> = {
   [K in keyof T]: T[K] extends object ? DeepExpandType<T[K]> : T[K];
 };


### PR DESCRIPTION
## Background

When `snapshot` used with [shineout](https://github.com/sheinsight/shineout), [antd](https://github.com/ant-design/ant-design) or other UI component libraries, TS types may not be compatible with `readonly`, such as:

```ts
import { create } from "@shined/reactive";
import { Select } from "shineout";

const store = create({
  options: ["test"],
});

export default function Foo() {
  const state = store.useSnapshot();

  // ❌ Error: type "readonly string[]" is "readonly"，can not be assigned to type "string[]"
  return <Select data={state.options} />;
}
```

## Solution

Add a type declare file to redeclare module to "hack" to remove `readonly`, this dts file just redefine this module, and remove types with `readonly`, so it won't affect the runtime.


Changes can be found [here](https://github.com/sheinsight/reactive/pull/8/files).

```typescript
// add this line to your global type file, like `env.d.ts`, `global.d.ts` or ect.

// use typescript triple-slash directive
/// <reference types="@shined/reactive/hack-remove-readonly" />
```