### PR TITLE
fix: fix object reference issue in `useEffect` & deprecated `original`

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,28 +275,6 @@ const snapshot = store.useSnapshot({ sync: true });
 
 </details>
 
-<details>
-<summary>❓ When snapshot in useEffect deps, Component enters an infinite loop.</summary>
-
-```tsx
-const snap = store.useSnapshot();
-
-// ❌ Error: You will fall into an infinite loop.
-useEffect(() => {
-  // some side effect
-}, [snap.address]);
-```
-
-🤔 Why?
-
-Because the snapshot object is recreated every time, each time it is a new object, so useEffect will think that the value of snapshot.address has changed, thus entering an infinite loop.
-
-🤡 How to solve it?
-
-You can use the `original` function to solve this problem. see [Subscribe store in component](#Subscribe-store-in-component) for more details.
-
-</details>
-
 ## Examples
 
 - [base-example](https://stackblitz.com/edit/vitejs-vite-zli31f?file=src%2Fmain.tsx)

--- a/examples/use-effect/src/app.tsx
+++ b/examples/use-effect/src/app.tsx
@@ -1,12 +1,12 @@
+import { useEffect } from "react";
+// import { original } from "@shined/reactive";
+
 import { store } from "./store";
 import "./app.css";
-import { useEffect } from "react";
-import { original } from "@shined/reactive";
 
 export default function App() {
   const snap = store.useSnapshot();
-
-  const address = original(snap.user.address);
+  const address = snap.user.address;
 
   useEffect(() => {
     console.log(address);

--- a/packages/reactive/README.md
+++ b/packages/reactive/README.md
@@ -144,22 +144,13 @@ import { useSubscribe } from "@shined/reactive";
 export default function Foo() {
   const snap = store.useSnapshot();
 
-  useSubscribe(
-    () => {
-      // do something when `store.users` changes
+  // Use "original" to obtain the raw data within the snapshot.
+  // This data can be applied to the deps of useEffect to avoid infinite execution of useEffect.
+  const address = original(snap.user.address);
 
-      // ❌ Error: You will fall into an infinite loop.
-      store.mutate.users = [];
-    },
-    {
-      // watch changes of `store.users`
-      // 🤡 deps You must get from store, snap cannot be used as deps for useSubscribe.
-      deps: [store.mutate.users],
-
-      // By default, useSubscribe will be executed asynchronously. If you want to execute it synchronously, you can open this configuration option.
-      sync: true,
-    }
-  );
+  useEffect(() => {
+    console.log(address);
+  }, [address]);
 
   return (
     <>
@@ -202,7 +193,6 @@ You want to share an instance of a component among multiple components in order 
 ## FAQs
 
 <details>
-
 <summary>❓ TS type error, `readonly` type can not be assigned to mutable type</summary>
 
 This error commonly occurs when using [shineout](https://github.com/sheinsight/shineout), [antd](https://github.com/ant-design/ant-design) or other UI component libraries and passing the `snapshot` to the component props, but the props type can not accept `readonly` type.
@@ -217,7 +207,6 @@ To resolve this type issue, add following line to your **global types file**, su
 </details>
 
 <details>
-
 <summary>❓ Cannot mutate the snapshot props in Child components</summary>
 
 The React philosophy is that **props should be immutable and top-down**. So, in principle, you should **NOT** change the props value inside components.
@@ -249,12 +238,11 @@ export function Foo(props) {
 </details>
 
 <details>
-
 <summary>❓ Unrelated changes to the state cause component to re-render</summary>
 
-it's intentional. It means, it "uses" the entire snapshot object, and will trigger re-render if any changes to state.
+It's intentional, which means it "uses" the entire snapshot object, and will trigger re-render if any changes to state.
 
-```ts
+```js
 // trigger re-render when any state changes
 const snapshot = store.useSnapshot();
 // same as above
@@ -263,7 +251,7 @@ store.useSnapshot();
 
 If you don't need this feature, you should **explicitly** access the properties you need.
 
-```ts
+```js
 // this will only trigger re-render when `name` changes.
 const snapshot = store.useSnapshot();
 snapshot.name; // use `.name` latter.
@@ -277,7 +265,6 @@ const name = useSnapshot(store.mutate.name);
 </details>
 
 <details>
-
 <summary>❓ When passing state to `input` element, an exception occurred while typing Chinese</summary>
 
 State mutations are batched synchronously by default before triggering re-render to optimize rendering. If you want to disable it (such as consumed by `<input>` element), you can set `sync` option to `true` when creating snapshot to avoid this issue.
@@ -285,33 +272,6 @@ State mutations are batched synchronously by default before triggering re-render
 ```tsx
 const snapshot = store.useSnapshot({ sync: true });
 ```
-
-</details>
-
-<details>
-  <summary>❓ When snapshot in useEffect deps , Component enters an infinite loop.</summary>
-  
-```tsx
-const snap = store.useSnapshot();
-
-// ❌ Error: You will fall into an infinite loop.
-useEffect(() => {
-// some side effect
-},[snap.address]);
-
-```
-
-🤔 Why ?
-
-Because the snapshot object is recreated every time, each time it is a new object, so useEffect will think that the value of snapshot.address has changed, thus entering an infinite loop.
-
-🤡 How to solve it ?
-
-You can use the `useSubscribe` hook to solve this problem. see [Subscribe store in component](#Subscribe-store-in-component) for more details.
-
-
-
-
 
 </details>
 
@@ -323,4 +283,3 @@ You can use the `useSubscribe` hook to solve this problem. see [Subscribe store 
 ## License
 
 - [MIT](./LICENSE)
-```

--- a/packages/reactive/hack-remove-readonly.d.ts
+++ b/packages/reactive/hack-remove-readonly.d.ts
@@ -42,9 +42,10 @@ declare module "@shined/reactive" {
   function proxy<T extends object>(initState: T): T;
   function create<T extends object>(initState: T, options?: CreateOptions): CreateReturn<T>;
   function subscribe<T extends object>(proxyObject: T, callback: () => void): () => void;
-  function original<T extends object>(object: T): T;
   function useSnapshot<T extends object>(proxyState: T, options?: SnapshotOptions): T;
 
+  /** @deprecated */
+  function original<T extends object>(object: T): T;
   /** @deprecated */
   function useSubscribe(callback: any, options: UseSubscribeOptions): void;
 
@@ -56,8 +57,8 @@ declare module "@shined/reactive" {
     proxy,
     ref,
     subscribe,
-    original,
     useSnapshot,
+    original,
     useSubscribe,
   };
 }

--- a/packages/reactive/src/devtool.ts
+++ b/packages/reactive/src/devtool.ts
@@ -38,14 +38,16 @@ export function enableDevtool(
   state: ReturnType<typeof proxy>,
   options: DevtoolOptions,
   restore: () => void
-) {
+): false | (() => void) {
   if (!ext) {
     const infos = [
-      "to enable redux devtool, make sure you've installed it 👉",
+      "to enable redux devtools, make sure you've installed it 👉",
       "https://github.com/reduxjs/redux-devtools#redux-devtools",
     ];
 
-    throw new Error(infos.join(" "));
+    console.error(infos.join(" "));
+
+    return false;
   }
 
   const devtool = ext.connect(options as Config) as ConnectResponse;

--- a/packages/reactive/src/index.spec.ts
+++ b/packages/reactive/src/index.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vitest } from "vitest";
+import { renderHook } from "@testing-library/react-hooks/dom";
+
 import { create, proxy, subscribe, useSnapshot } from "./index.js";
-import { renderHook } from "@testing-library/react-hooks/dom/index.js";
 import { getSnapshot } from "./utils.js";
 
 const runMacroTask = (fn: Function) => setTimeout(fn, 0);

--- a/packages/reactive/src/original.ts
+++ b/packages/reactive/src/original.ts
@@ -1,5 +1,6 @@
 import { ORIGINAL } from "./utils.js";
 
+/** @deprecated */
 export function original<T>(object: T) {
   return object[ORIGINAL]?.() as T;
 }

--- a/packages/reactive/src/ref.ts
+++ b/packages/reactive/src/ref.ts
@@ -1,10 +1,10 @@
-const refSet = new WeakSet();
+const internal_refSet = new WeakSet();
 
 export function ref<T extends object>(o: T): T {
-  refSet.add(o);
+  internal_refSet.add(o);
   return o as T;
 }
 
 export function hasRef<T extends object>(k: T) {
-  return refSet.has(k);
+  return internal_refSet.has(k);
 }

--- a/packages/reactive/src/subscribe.ts
+++ b/packages/reactive/src/subscribe.ts
@@ -12,6 +12,7 @@ export function subscribe<T extends object>(
       callback();
       return;
     }
+
     if (!promise) {
       promise = Promise.resolve().then(() => {
         promise = undefined;
@@ -19,8 +20,10 @@ export function subscribe<T extends object>(
       });
     }
   };
-  (proxyObject as any)[LISTENERS].add(listener);
+
+  proxyObject[LISTENERS].add(listener);
+
   return () => {
-    (proxyObject as any)[LISTENERS].delete(listener);
+    proxyObject[LISTENERS].delete(listener);
   };
 }

--- a/packages/reactive/src/use-snapshot.ts
+++ b/packages/reactive/src/use-snapshot.ts
@@ -1,7 +1,7 @@
 import { useCallback, useRef } from "react";
 import { createProxy, isChanged } from "proxy-compare";
 import { useSyncExternalStoreWithSelector } from "use-sync-external-store/shim/with-selector.js";
-import { SNAPSHOT, getSnapshot } from "./utils.js";
+import { getSnapshot } from "./utils.js";
 import { subscribe } from "./subscribe.js";
 
 import type { DeepReadonly } from "./utils.js";
@@ -9,6 +9,9 @@ import type { DeepReadonly } from "./utils.js";
 export interface SnapshotOptions {
   sync?: boolean;
 }
+
+const globalTargetCache = new WeakMap<object, any>();
+const globalProxyCache = new WeakMap<object, any>();
 
 export function useSnapshot<T extends object>(
   proxyState: T,
@@ -35,7 +38,5 @@ export function useSnapshot<T extends object>(
 
   lastAffected.current = affected;
 
-  const proxy = createProxy(snapshot, affected);
-
-  return proxy;
+  return createProxy(snapshot, affected, globalProxyCache, globalTargetCache);
 }


### PR DESCRIPTION
- Fix object reference issue in `useEffect`.
- Deprecated function `original`.
- Throw warning instead of error when `redux devtools` is not installed, but the `devtool` option is set.
- Update readme.
- Imporve code structure.