### PR TITLE
chore: remove rendering refine to avoid issue caused by `proxy-compare`

### DIFF
--- a/packages/reactive/src/use-snapshot.ts
+++ b/packages/reactive/src/use-snapshot.ts
@@ -33,7 +33,15 @@ export function useSnapshot<T extends object>(
     _getSnapshot,
     _getSnapshot,
     (snap) => snap,
-    (a, b) => !isChanged(a, b, lastAffected.current, new WeakMap())
+    (a, b) => {
+      /**
+       *  disable rendering optimization temporarily to avoid render issue caused by`proxy-compare`
+       *  @see https://github.com/dai-shi/proxy-compare/issues/65
+       */
+      return false;
+
+      // return !isChanged(a, b, lastAffected.current, new WeakMap());
+    }
   );
 
   lastAffected.current = affected;

--- a/packages/reactive/src/use-snapshot.ts
+++ b/packages/reactive/src/use-snapshot.ts
@@ -35,7 +35,7 @@ export function useSnapshot<T extends object>(
     (snap) => snap,
     (a, b) => {
       /**
-       *  disable rendering optimization temporarily to avoid render issue caused by`proxy-compare`
+       *  disable rendering optimization temporarily to avoid render issue caused by `proxy-compare`
        *  @see https://github.com/dai-shi/proxy-compare/issues/65
        */
       return false;


### PR DESCRIPTION
- disable rendering optimization temporarily to avoid render issue caused by `proxy-compare`.